### PR TITLE
refactor: do not init MCPServer on DurableObject

### DIFF
--- a/bin/stdio-server.mjs
+++ b/bin/stdio-server.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // @ts-check
-import { server, setupServer } from "../dist/index.mjs";
+import { createServer } from "../dist/index.mjs";
 import { startStdioTransport } from "../dist/mcp/transport/stdio.mjs";
 
-setupServer(server);
+const server = createServer();
 
 const cleanup = await startStdioTransport(server);
 

--- a/packages/cloudflare/src/server/index.ts
+++ b/packages/cloudflare/src/server/index.ts
@@ -1,14 +1,12 @@
 import { McpAgent } from "agents/mcp";
-import { server, setupServer } from "bundlephobia-mcp";
+import { createServer } from "bundlephobia-mcp";
 import { Hono } from "hono";
 
 export class BundlephobiaAgent extends McpAgent {
-  server = server;
+  server = createServer();
 
-  // eslint-disable-next-line @typescript-eslint/require-await
-  override async init(): Promise<void> {
-    setupServer(this.server);
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  override async init(): Promise<void> {}
 }
 
 const app = new Hono();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,18 +3,18 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { PKG_NAME, PKG_VERSION } from "./constants";
 import { getNpmPackageInfo, getNpmPackageInfoHistory } from "./tools";
 
-export const server = new McpServer({
-  description:
-    "Fetch information about the bundle size and dependencies of npm packages. Or retrieve those information over the past versions.",
-  name: PKG_NAME,
-  version: PKG_VERSION,
-});
-
 /**
  * Attach all tools to the server.
  * @param server - The server to attach the tools to.
  */
-export const setupServer = (server: McpServer): void => {
+export const createServer = (): McpServer => {
+  const server = new McpServer({
+    description:
+      "Fetch information about the bundle size and dependencies of npm packages. Or retrieve those information over the past versions.",
+    name: PKG_NAME,
+    version: PKG_VERSION,
+  });
+
   server.tool(
     getNpmPackageInfo.name,
     getNpmPackageInfo.description,
@@ -70,4 +70,6 @@ export const setupServer = (server: McpServer): void => {
       }
     },
   );
+
+  return server;
 };


### PR DESCRIPTION
Static tool registration with the MCPServer prevents more initialization than necessary for hibernation, etc.