### PR TITLE
feat: add configuration instruction for HTTP Streamable Transport

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -17,7 +17,7 @@
     "postinstall": "wrangler types"
   },
   "dependencies": {
-    "agents": "0.0.76",
+    "agents": "0.0.80",
     "bundlephobia-mcp": "workspace:*",
     "clsx": "2.1.1",
     "hono": "4.7.8",

--- a/packages/cloudflare/src/App.tsx
+++ b/packages/cloudflare/src/App.tsx
@@ -10,6 +10,8 @@ import { Meta } from "./components/Meta";
 import { useBaseUrl } from "./hooks/useBaseUrl";
 import { useMCPConfigSnippet } from "./hooks/useConfigString";
 
+// https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_configuration-format
+
 const getSSEConfig = (sseEndpoint: string) => ({
   bundlephobia: {
     type: "sse",
@@ -17,12 +19,17 @@ const getSSEConfig = (sseEndpoint: string) => ({
   },
 });
 
+const getHTTPStreamConfig = (httpStreamEndpoint: string) => ({
+  bundlephobia: {
+    type: "http",
+    url: httpStreamEndpoint,
+  },
+});
+
 function App() {
   const baseUrl = useBaseUrl();
 
   const sseEndpoint = useMemo(() => new URL("/sse", baseUrl).href, [baseUrl]);
-  // for future use
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const httpStreamEndpoint = useMemo(
     () => new URL("/mcp", baseUrl).href,
     [baseUrl],
@@ -30,6 +37,12 @@ function App() {
 
   const sseConfig = useMemo(() => getSSEConfig(sseEndpoint), [sseEndpoint]);
   const sseConfigSnippet = useMCPConfigSnippet(sseConfig);
+
+  const httpStreamConfig = useMemo(
+    () => getHTTPStreamConfig(httpStreamEndpoint),
+    [httpStreamEndpoint],
+  );
+  const httpStreamConfigSnippet = useMCPConfigSnippet(httpStreamConfig);
 
   return (
     <>
@@ -69,13 +82,13 @@ function App() {
             </div>
           </article>
 
-          {/* <article className="prose prose-slate">
+          <article className="prose prose-slate">
             <h2>Configuration for Streamable HTTP Transport</h2>
             <div>
               <h3>Edit json configuration</h3>
               <CodeBlock
                 className="not-prose"
-                snippet={sseConfigSnippet.json}
+                snippet={httpStreamConfigSnippet.json}
                 title="mcp.json"
               />
             </div>
@@ -83,11 +96,11 @@ function App() {
               <h3>Add to VSCode</h3>
               <CodeBlock
                 className="not-prose"
-                snippet={sseConfigSnippet.vscodeCommand}
+                snippet={httpStreamConfigSnippet.vscodeCommand}
                 title="VSCode CLI"
               />
             </div>
-          </article> */}
+          </article>
 
           <article className="prose prose-slate">
             <h2>Configuration for SSE Transport</h2>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
   packages/cloudflare:
     dependencies:
       agents:
-        specifier: 0.0.76
-        version: 0.0.76(@cloudflare/workers-types@4.20250419.0)(react@19.1.0)
+        specifier: 0.0.80
+        version: 0.0.80(@cloudflare/workers-types@4.20250419.0)(react@19.1.0)
       bundlephobia-mcp:
         specifier: workspace:*
         version: link:../..
@@ -202,8 +202,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/provider-utils@2.2.7':
-    resolution: {integrity: sha512-kM0xS3GWg3aMChh9zfeM+80vEZfXzR3JEUBdycZLtbRZ2TRT8xOj3WodGHPb06sUK5yD7pAXC/P7ctsi2fvUGQ==}
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
@@ -212,8 +212,8 @@ packages:
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@1.2.11':
-    resolution: {integrity: sha512-+kPqLkJ3TWP6czaJPV+vzAKSUcKQ1598BUrcLHt56sH99+LhmIIW3ylZp0OfC3O6TR3eO1Lt0Yzw4R0mK6g9Gw==}
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -222,8 +222,8 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/ui-utils@1.2.10':
-    resolution: {integrity: sha512-GUj+LBoAlRQF1dL/M49jtufGqtLOMApxTpCmVjoRpIPt/dFALVL9RfqfvxwztyIwbK+IxGzcYjSGRsrWrj+86g==}
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
@@ -2063,13 +2063,13 @@ packages:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
 
-  agents@0.0.76:
-    resolution: {integrity: sha512-d3/g55heptq3BsC2cHnmgmZu9LG5dUucoYMh+yeY3yGM9rHijBkFWCXsK8cKQ8hkg01aorOk9UjLGUnSSqGt4w==}
+  agents@0.0.80:
+    resolution: {integrity: sha512-Nlk9ihz3ejhndYSteml0qKh0yj0GMNMewHcHngLrJR470qruacpeLkdldAhWIC6ezF8H2lwtaHTPveAG6jfO9A==}
     peerDependencies:
       react: '*'
 
-  ai@4.3.13:
-    resolution: {integrity: sha512-cC5HXItuOwGykSMacCPzNp6+NMTxeuTjOenztVgSJhdC9Z4OrzBxwkyeDAf4h1QP938ZFi7IBdq3u4lxVoVmvw==}
+  ai@4.3.15:
+    resolution: {integrity: sha512-TYKRzbWg6mx/pmTadlAEIhuQtzfHUV0BbLY72+zkovXwq/9xhcH24IlQmkyBpElK6/4ArS0dHdOOtR1jOPVwtg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -4067,8 +4067,8 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  partyserver@0.0.68:
-    resolution: {integrity: sha512-LdYuxyhFmu8M5Mx7+rTAAo9lfk22LUfbjXnaKUCXhwSABpgM66LNIjW8F1i2x/CSra1fzF3tIZFD5ojr3KeSQg==}
+  partyserver@0.0.70:
+    resolution: {integrity: sha512-v6hfcNFdSS+5pLBHXGXnuRH6m3luc2veWhd3klY2iOx3HXG17egHBP4oZ/Is1Qk5CmuNce8xXMqHp52+cxCAyw==}
     peerDependencies:
       '@cloudflare/workers-types': ^4.20240729.0
 
@@ -5233,41 +5233,38 @@ packages:
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
-  zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
-
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
 snapshots:
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.3)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.24.4)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.24.3
+      zod: 3.24.4
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.11(react@19.1.0)(zod@3.24.3)':
+  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.24.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      '@ai-sdk/ui-utils': 1.2.10(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.4)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.24.4)
       react: 19.1.0
       swr: 2.3.3(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.24.3
+      zod: 3.24.4
 
-  '@ai-sdk/ui-utils@1.2.10(zod@3.24.3)':
+  '@ai-sdk/ui-utils@1.2.11(zod@3.24.4)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.4)
+      zod: 3.24.4
+      zod-to-json-schema: 3.24.5(zod@3.24.4)
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -6922,29 +6919,29 @@ snapshots:
 
   agent-base@7.1.3: {}
 
-  agents@0.0.76(@cloudflare/workers-types@4.20250419.0)(react@19.1.0):
+  agents@0.0.80(@cloudflare/workers-types@4.20250419.0)(react@19.1.0):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.10.2
-      ai: 4.3.13(react@19.1.0)(zod@3.24.3)
+      '@modelcontextprotocol/sdk': 1.11.1
+      ai: 4.3.15(react@19.1.0)(zod@3.24.4)
       cron-schedule: 5.0.4
       nanoid: 5.1.5
-      partyserver: 0.0.68(@cloudflare/workers-types@4.20250419.0)
+      partyserver: 0.0.70(@cloudflare/workers-types@4.20250419.0)
       partysocket: 1.1.3
       react: 19.1.0
-      zod: 3.24.3
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - supports-color
 
-  ai@4.3.13(react@19.1.0)(zod@3.24.3):
+  ai@4.3.15(react@19.1.0)(zod@3.24.4):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      '@ai-sdk/react': 1.2.11(react@19.1.0)(zod@3.24.3)
-      '@ai-sdk/ui-utils': 1.2.10(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.4)
+      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.24.4)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.24.4)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.24.3
+      zod: 3.24.4
     optionalDependencies:
       react: 19.1.0
 
@@ -9223,7 +9220,7 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  partyserver@0.0.68(@cloudflare/workers-types@4.20250419.0):
+  partyserver@0.0.70(@cloudflare/workers-types@4.20250419.0):
     dependencies:
       '@cloudflare/workers-types': 4.20250419.0
       nanoid: 5.1.5
@@ -10522,16 +10519,10 @@ snapshots:
     dependencies:
       zod: 3.24.4
 
-  zod-to-json-schema@3.24.5(zod@3.24.3):
-    dependencies:
-      zod: 3.24.3
-
   zod-to-json-schema@3.24.5(zod@3.24.4):
     dependencies:
       zod: 3.24.4
 
   zod@3.22.3: {}
-
-  zod@3.24.3: {}
 
   zod@3.24.4: {}


### PR DESCRIPTION
Since VSCode officially supported HTTP Streamble Transport Remote MCP in 1.100 release.
ref: https://code.visualstudio.com/updates/v1_100#_mcp-support-for-streamable-http