### PR TITLE
docs: add stdio installation guide and cursor deeplink improvements

### DIFF
--- a/packages/cloudflare/src/App.tsx
+++ b/packages/cloudflare/src/App.tsx
@@ -8,7 +8,7 @@ import { CodeBlock } from "./components/CodeBlock";
 import { InstallToCursor } from "./components/InstallToCursor";
 import { Meta } from "./components/Meta";
 import { useBaseUrl } from "./hooks/useBaseUrl";
-import { useMCPConfigSnippet } from "./hooks/useConfigString";
+import { createMCPConfigSnippet } from "./utils/configSnippet";
 
 const MCP_CONFIG_SERVER_NAME = "bundlephobia";
 
@@ -20,12 +20,15 @@ function App() {
     [baseUrl],
   );
 
-  const httpStreamConfigSnippet = useMCPConfigSnippet(MCP_CONFIG_SERVER_NAME, {
-    type: "http",
-    url: httpStreamEndpoint,
-  });
+  const httpStreamConfigSnippet = createMCPConfigSnippet(
+    MCP_CONFIG_SERVER_NAME,
+    {
+      type: "http",
+      url: httpStreamEndpoint,
+    },
+  );
 
-  const npxStdioSnippet = useMCPConfigSnippet(MCP_CONFIG_SERVER_NAME, {
+  const npxStdioSnippet = createMCPConfigSnippet(MCP_CONFIG_SERVER_NAME, {
     args: ["bundlephobia-mcp"],
     command: "npx",
     type: "stdio",

--- a/packages/cloudflare/src/App.tsx
+++ b/packages/cloudflare/src/App.tsx
@@ -3,20 +3,14 @@ import {
   TOOL_TITLE,
 } from "bundlephobia-mcp/internal/constants";
 import { useMemo } from "react";
-import Fa6SolidCircleInfo from "~icons/fa6-solid/circle-info";
 
 import { CodeBlock } from "./components/CodeBlock";
+import { InstallToCursor } from "./components/InstallToCursor";
 import { Meta } from "./components/Meta";
 import { useBaseUrl } from "./hooks/useBaseUrl";
 import { useMCPConfigSnippet } from "./hooks/useConfigString";
 
-// https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_configuration-format
-const getHTTPStreamConfig = (httpStreamEndpoint: string) => ({
-  bundlephobia: {
-    type: "http",
-    url: httpStreamEndpoint,
-  },
-});
+const MCP_CONFIG_SERVER_NAME = "bundlephobia";
 
 function App() {
   const baseUrl = useBaseUrl();
@@ -26,11 +20,16 @@ function App() {
     [baseUrl],
   );
 
-  const httpStreamConfig = useMemo(
-    () => getHTTPStreamConfig(httpStreamEndpoint),
-    [httpStreamEndpoint],
-  );
-  const httpStreamConfigSnippet = useMCPConfigSnippet(httpStreamConfig);
+  const httpStreamConfigSnippet = useMCPConfigSnippet(MCP_CONFIG_SERVER_NAME, {
+    type: "http",
+    url: httpStreamEndpoint,
+  });
+
+  const npxStdioSnippet = useMCPConfigSnippet(MCP_CONFIG_SERVER_NAME, {
+    args: ["bundlephobia-mcp"],
+    command: "npx",
+    type: "stdio",
+  });
 
   return (
     <>
@@ -58,16 +57,6 @@ function App() {
                 bundlephobia.com
               </a>
             </p>
-
-            <div className="bg-blue-50 border-l-4 border-blue-400 p-4 mb-6 rounded-md not-prose">
-              <p className="text-blue-700 flex items-center">
-                <Fa6SolidCircleInfo className="h-5 w-5 mr-2 text-current" />
-                <span>
-                  Support for StreamableHTTPServerTransport is implemented. But
-                  not available for most MCP Clients, So it is not documented.
-                </span>
-              </p>
-            </div>
           </article>
 
           <article className="prose prose-slate">
@@ -82,19 +71,43 @@ function App() {
             </div>
             <div>
               <h3>Add to Cursor</h3>
-              <a href="https://cursor.com/install-mcp?name=bundlephobia&config=eyJ0eXBlIjoiaHR0cCIsInVybCI6Imh0dHBzOi8vYnVuZGxlcGhvYmlhLW1jcC5zdXNoaWNoYW4wNDQud29ya2Vycy5kZXYvbWNwIn0%3D">
-                <img
-                  alt="Add bundlephobia MCP server to Cursor"
-                  height="32"
-                  src="https://cursor.com/deeplink/mcp-install-dark.svg"
-                />
-              </a>
+              <InstallToCursor
+                installationLink={httpStreamConfigSnippet.cursorInstallLink}
+              />
             </div>
             <div>
               <h3>Add to VSCode</h3>
               <CodeBlock
                 className="not-prose"
                 snippet={httpStreamConfigSnippet.vscodeCommand}
+                title="VSCode CLI"
+              />
+            </div>
+          </article>
+
+          <hr className="prose prose-slate" />
+
+          <article className="prose prose-slate">
+            <h2>Configuration for Stdio Transport</h2>
+            <div>
+              <h3>Edit json configuration</h3>
+              <CodeBlock
+                className="not-prose"
+                snippet={npxStdioSnippet.json}
+                title="mcp.json"
+              />
+            </div>
+            <div>
+              <h3>Add to Cursor</h3>
+              <InstallToCursor
+                installationLink={npxStdioSnippet.cursorInstallLink}
+              />
+            </div>
+            <div>
+              <h3>Add to VSCode</h3>
+              <CodeBlock
+                className="not-prose"
+                snippet={npxStdioSnippet.vscodeCommand}
                 title="VSCode CLI"
               />
             </div>

--- a/packages/cloudflare/src/components/InstallToCursor.tsx
+++ b/packages/cloudflare/src/components/InstallToCursor.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  installationLink: string;
+};
+
+export const InstallToCursor = ({ installationLink }: Props) => {
+  return (
+    <a href={installationLink} rel="noopener noreferrer" target="_blank">
+      <img
+        alt="Add bundlephobia MCP server to Cursor"
+        height="32"
+        src="https://cursor.com/deeplink/mcp-install-dark.svg"
+      />
+    </a>
+  );
+};

--- a/packages/cloudflare/src/hooks/useConfigString.ts
+++ b/packages/cloudflare/src/hooks/useConfigString.ts
@@ -2,19 +2,51 @@ import { useMemo } from "react";
 
 /**
  * Returns the MCP config as a json snippet or a vscode command to add the config to the current workspace.
- * @param configJson The MCP config as a json object.
+ *
+ * @param name The name of the MCP config.
+ * @param rawConfig The MCP config as a json object without the name.
  */
-export const useMCPConfigSnippet = (configJson: Record<string, unknown>) => {
-  const json = useMemo(() => {
-    return JSON.stringify(configJson, null, 2);
-  }, [configJson]);
+export const useMCPConfigSnippet = (
+  name: string,
+  rawConfig: Record<string, unknown>,
+) => {
+  const jsonWithName = useMemo(() => {
+    return {
+      [name]: rawConfig,
+    };
+  }, [name, rawConfig]);
+
+  const prettyJSON = useMemo(() => {
+    return JSON.stringify(jsonWithName, null, 2);
+  }, [jsonWithName]);
 
   const vscodeCommand = useMemo(() => {
-    return `code --add-mcp '${JSON.stringify(configJson)}'`;
-  }, [configJson]);
+    return `code --add-mcp '${JSON.stringify(jsonWithName)}'`;
+  }, [jsonWithName]);
+
+  const cursorInstallLink = useMemo(() => {
+    return buildCursorInstallLink(name, rawConfig);
+  }, [name, rawConfig]);
 
   return {
-    json,
+    cursorInstallLink,
+    json: prettyJSON,
     vscodeCommand,
   };
+};
+
+/**
+ *
+ * @param name The name of the MCP config.
+ * @param rawConfigJSON The MCP config as a json object without the name.
+ * @returns A link to install the MCP config in Cursor.
+ *
+ * @see {@link https://docs.cursor.com/deeplinks#mcp}
+ */
+const buildCursorInstallLink = (
+  name: string,
+  rawConfigJSON: Record<string, unknown>,
+) => {
+  const base64Config = btoa(JSON.stringify(rawConfigJSON));
+  return `cursor://anysphere.cursor-deeplink/mcp/install?name=${name}&config=${base64Config}`;
 };

--- a/packages/cloudflare/src/utils/configSnippet.ts
+++ b/packages/cloudflare/src/utils/configSnippet.ts
@@ -1,32 +1,20 @@
-import { useMemo } from "react";
-
 /**
  * Returns the MCP config as a json snippet or a vscode command to add the config to the current workspace.
  *
  * @param name The name of the MCP config.
  * @param rawConfig The MCP config as a json object without the name.
  */
-export const useMCPConfigSnippet = (
+export const createMCPConfigSnippet = (
   name: string,
   rawConfig: Record<string, unknown>,
 ) => {
-  const jsonWithName = useMemo(() => {
-    return {
-      [name]: rawConfig,
-    };
-  }, [name, rawConfig]);
+  const jsonWithName = {
+    [name]: rawConfig,
+  };
 
-  const prettyJSON = useMemo(() => {
-    return JSON.stringify(jsonWithName, null, 2);
-  }, [jsonWithName]);
-
-  const vscodeCommand = useMemo(() => {
-    return `code --add-mcp '${JSON.stringify(jsonWithName)}'`;
-  }, [jsonWithName]);
-
-  const cursorInstallLink = useMemo(() => {
-    return buildCursorInstallLink(name, rawConfig);
-  }, [name, rawConfig]);
+  const prettyJSON = JSON.stringify(jsonWithName, null, 2);
+  const vscodeCommand = `code --add-mcp '${JSON.stringify(jsonWithName)}'`;
+  const cursorInstallLink = buildCursorInstallLink(name, rawConfig);
 
   return {
     cursorInstallLink,
@@ -36,6 +24,7 @@ export const useMCPConfigSnippet = (
 };
 
 /**
+ * Builds a cursor install link for the MCP config.
  *
  * @param name The name of the MCP config.
  * @param rawConfigJSON The MCP config as a json object without the name.


### PR DESCRIPTION
## Summary
- Add stdio transport installation guide alongside HTTP configuration
- Refactor config snippet generation to use pure logic instead of React hooks
- Improve Cursor deeplink functionality with proper component separation

## Changes
- Moved `useMCPConfigSnippet` hook to pure `createMCPConfigSnippet` utility function
- Added dedicated `InstallToCursor` component for better reusability
- Added stdio transport configuration section to documentation
- Removed SSE transport notice as it's not currently supported

## Test plan
- [x] Verify HTTP configuration still works
- [x] Test new stdio configuration generates correct JSON
- [x] Confirm Cursor deeplinks work for both HTTP and stdio configs
- [x] Check VSCode commands are properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)