### PR TITLE
refactor: concise structured output schema helper

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 22.15.19
       '@virtual-live-lab/eslint-config':
         specifier: catalog:dev
-        version: 2.2.22(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(tailwindcss@4.1.10)(typescript@5.8.3)
+        version: 2.2.22(@typescript-eslint/parser@8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(tailwindcss@4.1.10)(typescript@5.8.3)
       '@virtual-live-lab/prettier-config':
         specifier: catalog:dev
         version: 2.0.19(prettier@3.5.3)
@@ -6308,6 +6308,38 @@ snapshots:
       '@typescript-eslint/types': 8.34.1
       eslint-visitor-keys: 4.2.1
 
+  '@virtual-live-lab/eslint-config@2.2.22(@typescript-eslint/parser@8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(tailwindcss@4.1.10)(typescript@5.8.3)':
+    dependencies:
+      '@astrojs/compiler': 2.12.0
+      '@eslint/compat': 1.2.9(eslint@9.29.0(jiti@2.4.2))
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.28.0
+      '@stylistic/eslint-plugin-ts': 4.4.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      astro-eslint-parser: 1.2.2
+      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@2.12.0)
+      eslint: 9.29.0(jiti@2.4.2)
+      eslint-config-flat-gitignore: 2.1.0(eslint@9.29.0(jiti@2.4.2))
+      eslint-config-prettier: 10.1.5(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-astro: 1.3.1(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-perfectionist: 4.14.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint-plugin-react: 7.37.5(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-react-refresh: 0.4.20(eslint@9.29.0(jiti@2.4.2))
+      eslint-plugin-tailwindcss: 3.18.0(tailwindcss@4.1.10)
+      globals: 16.2.0
+      pkg-dir: 8.0.0
+      typescript-eslint: 8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      typescript-eslint-parser-for-extra-files: 0.9.0(@typescript-eslint/parser@8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.12.0))(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - supports-color
+      - svelte2tsx
+      - tailwindcss
+      - typescript
+      - vue
+
   '@virtual-live-lab/eslint-config@2.2.22(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(tailwindcss@4.1.10)(typescript@5.8.3)':
     dependencies:
       '@astrojs/compiler': 2.12.0
@@ -9416,6 +9448,14 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-eslint-parser-for-extra-files@0.9.0(@typescript-eslint/parser@8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.12.0))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/parser': 8.33.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@2.12.0)
+      typescript: 5.8.3
 
   typescript-eslint-parser-for-extra-files@0.9.0(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.12.0))(typescript@5.8.3):
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "./api/size";
 import { PKG_NAME, PKG_VERSION } from "./constants";
 import {
-  packageStatsHistoryMCPOutputSchema,
+  structuredPackageStatsHistoryOutput,
   structuredPackageStatsOutput,
 } from "./structured-output";
 import { isNonEmptyString } from "./utils/string";
@@ -116,12 +116,12 @@ export const createServer = (): McpServer => {
           .string()
           .describe("The name of the npm package to get information about."),
       },
-      outputSchema: packageStatsHistoryMCPOutputSchema.schema,
+      outputSchema: structuredPackageStatsHistoryOutput.schema,
     },
     async ({ name }) => {
       try {
         if (!isNonEmptyString(name)) {
-          return packageStatsHistoryMCPOutputSchema.error({
+          return structuredPackageStatsHistoryOutput.error({
             code: "InvalidInputError",
             messages: ["Package name must be a non-empty string"],
           });
@@ -129,15 +129,15 @@ export const createServer = (): McpServer => {
         const packageInfo = await fetchPackageHistory(name);
 
         if (isPackageHistoryAPIErrorResponse(packageInfo)) {
-          return packageStatsHistoryMCPOutputSchema.error(
+          return structuredPackageStatsHistoryOutput.error(
             structuredErrorOfPackageHistoryAPI(packageInfo),
           );
         }
 
-        return packageStatsHistoryMCPOutputSchema.success(packageInfo);
+        return structuredPackageStatsHistoryOutput.success(packageInfo);
       } catch (error) {
         console.error(error);
-        return packageStatsHistoryMCPOutputSchema.error({
+        return structuredPackageStatsHistoryOutput.error({
           code: "FetchError",
           messages: [
             "An error occurred while fetching the package history from bundlephobia.",


### PR DESCRIPTION
## 概要
- 構造化出力の形式を簡潔化
- lockfileを更新

## 変更内容
- `structured-output.ts`でより簡潔な出力構造に変更
- `packageStatsHistoryMCPOutputSchema`を`structuredPackageStatsHistoryOutput`に統一

## テストプラン
- [x] `pnpm build`で正常にビルドされることを確認
- [x] `pnpm test`でテストが通ることを確認
- [x] `pnpm check`で全体のチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal naming and structure of output formatting for package statistics history, improving consistency in error and result handling.
- **Chores**
	- Renamed functions and constants related to structured output for clarity and alignment with updated schema handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->