### PR TITLE
feat: add Claude Code integration sections

### DIFF
--- a/packages/cloudflare/src/App.tsx
+++ b/packages/cloudflare/src/App.tsx
@@ -86,6 +86,26 @@ function App() {
                 title="VSCode CLI"
               />
             </div>
+            <div>
+              <h3>Add to Claude Code</h3>
+              <p className="text-slate-600 text-sm">
+                See{" "}
+                <a
+                  className="underline hover:brightness-50 transition-all"
+                  href="https://docs.anthropic.com/en/docs/claude-code/mcp"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Claude Code MCP documentation
+                </a>{" "}
+                for setup instructions.
+              </p>
+              <CodeBlock
+                className="not-prose"
+                snippet={httpStreamConfigSnippet.json}
+                title="mcp_settings.json"
+              />
+            </div>
           </article>
 
           <hr className="prose prose-slate" />
@@ -112,6 +132,26 @@ function App() {
                 className="not-prose"
                 snippet={npxStdioSnippet.vscodeCommand}
                 title="VSCode CLI"
+              />
+            </div>
+            <div>
+              <h3>Add to Claude Code</h3>
+              <p className="text-slate-600 text-sm">
+                See{" "}
+                <a
+                  className="underline hover:brightness-50 transition-all"
+                  href="https://docs.anthropic.com/en/docs/claude-code/mcp"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Claude Code MCP documentation
+                </a>{" "}
+                for setup instructions.
+              </p>
+              <CodeBlock
+                className="not-prose"
+                snippet={npxStdioSnippet.json}
+                title="mcp_settings.json"
               />
             </div>
           </article>


### PR DESCRIPTION
Add Claude Code configuration sections to the documentation site for both HTTP Streamable Transport and Stdio Transport options. Each section includes the appropriate JSON configuration and links to the official Claude Code MCP documentation for setup instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Add to Claude Code” panels under configuration for Streamable HTTP and Stdio transports, each with a link to Claude Code MCP docs and a ready-to-copy mcp_settings.json snippet. Panels appear after the existing “Add to VSCode” sections.

* **Documentation**
  * Enhanced in-app guidance for integrating with Claude Code, including clear instructions and snippets for both transport options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->