### PR TITLE
refactor: construct claude-code compatible JSON in `createMCPConfigSnippet`

### DIFF
--- a/packages/cloudflare/src/App.tsx
+++ b/packages/cloudflare/src/App.tsx
@@ -102,8 +102,8 @@ function App() {
               </p>
               <CodeBlock
                 className="not-prose"
-                snippet={httpStreamConfigSnippet.json}
-                title="mcp_settings.json"
+                snippet={httpStreamConfigSnippet.claudeCodeJSON}
+                title=".mcp.json"
               />
             </div>
           </article>
@@ -150,8 +150,8 @@ function App() {
               </p>
               <CodeBlock
                 className="not-prose"
-                snippet={npxStdioSnippet.json}
-                title="mcp_settings.json"
+                snippet={npxStdioSnippet.claudeCodeJSON}
+                title=".mcp.json"
               />
             </div>
           </article>

--- a/packages/cloudflare/src/utils/configSnippet.ts
+++ b/packages/cloudflare/src/utils/configSnippet.ts
@@ -15,8 +15,10 @@ export const createMCPConfigSnippet = (
   const prettyJSON = JSON.stringify(jsonWithName, null, 2);
   const vscodeCommand = `code --add-mcp '${JSON.stringify(jsonWithName)}'`;
   const cursorInstallLink = buildCursorInstallLink(name, rawConfig);
+  const claudeCodeJSON = JSON.stringify({ mcpServers: jsonWithName }, null, 2);
 
   return {
+    claudeCodeJSON,
     cursorInstallLink,
     json: prettyJSON,
     vscodeCommand,


### PR DESCRIPTION
https://github.com/sushichan044/bundlephobia-mcp/pull/146#issuecomment-3200104457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Claude Code JSON snippets for both Streamable HTTP and Stdio transports, improving copy-paste readiness for code blocks.
  * Updated displayed filename in Claude Code blocks from “mcp_settings.json” to “.mcp.json” for clearer configuration guidance.
  * Enhanced configuration snippet generation to expose a Claude Code–friendly JSON format alongside existing outputs, ensuring consistent setup across editors and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->